### PR TITLE
#158 Versions of requirements.txt ETL Package

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,12 +4,12 @@ cachetools==6.2.0
 certifi==2025.10.5
 charset-normalizer==3.4.3
 colorama==0.4.6
-google-ai-generativelanguage==0.6.15
 google-api-core==2.25.2
 google-api-python-client==2.184.0
 google-auth==2.41.1
 google-auth-httplib2==0.2.0
 google-generativeai==0.8.5
+google-ai-generativelanguage==0.9.0  # Required by langchain-google-genai; causes warning with google-generativeai but works in practice
 googleapis-common-protos==1.70.0
 grpcio==1.75.1
 grpcio-status==1.71.2
@@ -40,14 +40,17 @@ pyjwt==2.9.0
 asyncpg==0.30.0
 
 # packages for ETL
-langchain
-langchain-google-genai
-pypdf
-unstructured
-psycopg2-binary
-pgvector
-langchain-community
-bs4
-playwright
-html2text
-typing
+langchain==1.0.8
+langchain-core==1.1.0
+langchain-community==0.4.1
+langchain-classic==1.0.0
+langchain-text-splitters==1.0.0
+langchain-google-genai==2.1.12
+pypdf==6.1.3
+unstructured==0.18.18
+psycopg2-binary==2.9.11
+pgvector==0.4.1
+bs4==0.0.2
+playwright==1.56.0
+html2text==2025.4.15
+typing==3.7.4.3

--- a/data_ingestion/etl_pipeline.py
+++ b/data_ingestion/etl_pipeline.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 from typing import List
-from langchain.schema import Document
+from langchain_core.documents import Document
 import data_ingestion.extractor as extractor
 import data_ingestion.processor as processor
 from langchain_community.vectorstores.pgvector import PGVector

--- a/data_ingestion/extractor.py
+++ b/data_ingestion/extractor.py
@@ -1,6 +1,6 @@
 from langchain_community.document_loaders import PyPDFLoader, UnstructuredURLLoader
 from typing import List, Set
-from langchain.schema import Document
+from langchain_core.documents import Document
 import re
 import requests
 from bs4 import BeautifulSoup

--- a/data_ingestion/processor.py
+++ b/data_ingestion/processor.py
@@ -1,6 +1,6 @@
-from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_text_splitters import RecursiveCharacterTextSplitter
 from typing import List
-from langchain.schema import Document
+from langchain_core.documents import Document
 import re
 import os
 from html2text import HTML2Text


### PR DESCRIPTION
Updated ETL Packages (with versions):

  Core Langchain packages:
  - langchain==1.0.8 (was: unversioned)
  - langchain-core==1.1.0 (new dependency)
  - langchain-community==0.4.1 (was: unversioned)
  - langchain-classic==1.0.0 (new dependency)
  - langchain-text-splitters==1.0.0 (new dependency)
  - langchain-google-genai==2.1.12 (was: unversioned)

  Data processing packages:
  - pypdf==6.1.3 (was: unversioned)
  - unstructured==0.18.18 (was: unversioned)
  - html2text==2025.4.15 (was: missing)

  Database packages:
  - psycopg2-binary==2.9.11 (was: unversioned)
  - pgvector==0.4.1 (was: unversioned)

  Web scraping packages:
  - bs4==0.0.2 (was: unversioned)
  - playwright==1.56.0 (was: unversioned)

  Other:
  - google-ai-generativelanguage==0.9.0 (updated with note about compatibility)
  - typing==3.7.4.3 (was: unversioned)